### PR TITLE
Add sketch-based acceleration to Scanorama API

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@
 
 Scanorama enables batch-correction and integration of heterogeneous scRNA-seq data sets, which is described in the paper ["Efficient integration of heterogeneous single-cell transcriptomes using Scanorama"](https://www.nature.com/articles/s41587-019-0113-3) by Brian Hie, Bryan Bryson, and Bonnie Berger. This repository contains the Scanorama source code as well as scripts necessary for reproducing the results in the paper.
 
-**Scanorama is designed to be used in scRNA-seq pipelines downstream of noise-reduction methods, including those for imputation and highly-variable gene filtering. The results from Scanorama integration and batch correction can then be used as input to other tools for scRNA-seq clustering, visualization, and analysis.**
+Scanorama is designed to be used in scRNA-seq pipelines downstream of noise-reduction methods, including those for imputation and highly-variable gene filtering. The results from Scanorama integration and batch correction can then be used as input to other tools for scRNA-seq clustering, visualization, and analysis.
+
+Scanorama integration can also be greatly accelerated using tools for data sketching, as described in the paper ["Geometric sketching compactly summarizes the single-cell transcriptomic landscape", Cell Systems (2019)](https://www.cell.com/cell-systems/fulltext/S2405-4712\(19\)30152-8) and implemented [here](https://github.com/brianhie/geosketch).
 
 ## API example usage
 
@@ -88,7 +90,7 @@ cd scanorama/
 python setup.py install --user
 ```
 
-If you are running inside an anaconda environment, first install annoy by doing: 
+If you are running inside an anaconda environment, first install annoy by doing:
 ```
 conda install -c conda-forge python-annoy
 ```
@@ -166,11 +168,9 @@ For those interested in the algorithm implementation, `scanorama/scanorama.py` i
 
 - Make sure the input matrices are cells-by-genes, not the transpose.
 
+- For large data set integration under memory constraints (e.g., if you run into a `MemoryError`), try lowering the `batch_size` parameter to improve memory usage and try sketch-based acceleration using the `sketch` parameter to `integrate()` to improve both memory usage and runtime.
+
 - For the example scripts, be sure to run `bin/process.py` first, although this is not necessary if you are using Scanorama through the API.
-
-- For large data set integration under memory constraints (e.g., if you run into a `MemoryError`), try lowering the `batch_size` parameter. And stay tuned for more improvements!
-
-- Scanorama versions 0.2 through 0.6.1 had default parameters that resulted in non-optimal batch correction results (integration was unaffected). Upgrade to the latest version for a fix to this issue.
 
 ## Questions
 

--- a/bin/mouse_brain_sketched.py
+++ b/bin/mouse_brain_sketched.py
@@ -10,7 +10,7 @@ from process import load_names, process
 
 np.random.seed(0)
 
-NAMESPACE = 'mouse_brain'
+NAMESPACE = 'mouse_brain_sketched'
 BATCH_SIZE = 10000
 
 data_names = [
@@ -36,17 +36,11 @@ if __name__ == '__main__':
     datasets_dimred, genes = process_data(datasets, genes, verbose=True)
 
     t0 = time()
-    datasets_dimred = assemble(
-        datasets_dimred, batch_size=BATCH_SIZE,
-    )
-    print('Integrated panoramas in {:.3f}s'.format(time() - t0))
-
-    t0 = time()
-    datasets_dimred, datasets, genes = correct(
+    datasets_dimred, genes = integrate(
         datasets, genes_list, ds_names=data_names,
-        return_dimred=True, batch_size=BATCH_SIZE,
+        sketch=True, sketch_method='geosketch', sketch_max=2000,
     )
-    print('Integrated and batch corrected panoramas in {:.3f}s'
+    print('Sketched and integrated panoramas in {:.3f}s'
           .format(time() - t0))
 
     labels = []
@@ -79,8 +73,6 @@ if __name__ == '__main__':
                           gene_expr=vstack(datasets),
                           multicore_tsne=True,
                           image_suffix='.png')
-    np.savetxt('data/{}_embedding.txt'.format(NAMESPACE),
-               embedding, delimiter='\t')
 
     cell_labels = (
         open('data/cell_labels/mouse_brain_cluster.txt')

--- a/scanorama/__init__.py
+++ b/scanorama/__init__.py
@@ -1,1 +1,3 @@
 from .scanorama import *
+
+__version__ = 1.5

--- a/setup.py
+++ b/setup.py
@@ -2,14 +2,15 @@ from setuptools import setup, find_packages
 
 setup(
     name='scanorama',
-    version='1.4',
+    version='1.5',
     description='Panoramic stitching of heterogeneous single cell transcriptomic data',
     url='https://github.com/brianhie/scanorama',
-    download_url='https://github.com/brianhie/scanorama/archive/v1.4.tar.gz',
+    download_url='https://github.com/brianhie/scanorama/archive/v1.5.tar.gz',
     packages=find_packages(exclude=['bin', 'conf', 'data', 'target']),
     install_requires=[
         'annoy>=1.11.5',
         'fbpca>=1.0',
+        'geosketch>=1.0',
         'intervaltree==2.1.0',
         'matplotlib>=2.0.2',
         'numpy>=1.12.0',


### PR DESCRIPTION
Main improvements:
- `sketch` parameter as part of `integrate()`.
Other details:
- Added sketching reference in README.
- Removed defunct parameters in API and interpretation function.
- Added mouse brain example with sketching.