### PR TITLE
This is producing a syntax error on bioconda

### DIFF
--- a/scanorama/__init__.py
+++ b/scanorama/__init__.py
@@ -1,3 +1,3 @@
 from .scanorama import *
 
-__version__ = 1.5.1
+__version__ = "1.5.1"


### PR DESCRIPTION
Xref: https://circleci.com/gh/bioconda/bioconda-recipes/101186?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-checks-link

Most likely there should just be a 1.5.2 release with this small fix.