### PR TITLE
Keep adata.obs in correct_scanpy() function

### DIFF
--- a/scanorama/scanorama.py
+++ b/scanorama/scanorama.py
@@ -233,6 +233,7 @@ def correct_scanpy(adatas, **kwargs):
     for i in range(len((adatas))):
         adata = AnnData(datasets[i])
         adata.var_names = genes
+        adata.obs = adatas[i].obs
         new_adatas.append(adata)
 
     if 'return_dimred' in kwargs and kwargs['return_dimred']:


### PR DESCRIPTION
Hey!
Thanks for the great tool!

Unfortunately scanorama doesn't keep adata.obs when using `correct_scanpy()`.
This PR fixes that.