### PR TITLE
Update intervaltree dependency and version number

### DIFF
--- a/scanorama/__init__.py
+++ b/scanorama/__init__.py
@@ -1,3 +1,3 @@
 from .scanorama import *
 
-__version__ = '1.7.1'
+__version__ = '1.7.2'

--- a/setup.py
+++ b/setup.py
@@ -2,16 +2,15 @@ from setuptools import setup, find_packages
 
 setup(
     name='scanorama',
-    version='1.7.1',
+    version='1.7.2',
     description='Panoramic stitching of heterogeneous single cell transcriptomic data',
     url='https://github.com/brianhie/scanorama',
-    download_url='https://github.com/brianhie/scanorama/archive/v1.7.1.tar.gz',
     packages=find_packages(exclude=['bin', 'conf', 'data', 'target']),
     install_requires=[
         'annoy>=1.11.5',
         'fbpca>=1.0',
         'geosketch>=1.0',
-        'intervaltree==2.1.0',
+        'intervaltree>=3.1.0',
         'matplotlib>=2.0.2',
         'numpy>=1.12.0',
         'scipy>=1.0.0',


### PR DESCRIPTION
Need to update intervaltree as not compatible with Python 3.10 (https://github.com/brianhie/scanorama/issues/115)